### PR TITLE
Using Sintra's error block and Environment Variable

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -4,20 +4,24 @@ require 'rollbar'
 configure do
   Rollbar.configure do |config|
     config.access_token = 'aaaabbbbccccddddeeeeffff00001111'
-    config.environment = 'sinatra-test'
+    config.environment = Sinatra::Base.environment
     config.root = Dir.pwd
   end
 end
 
+error do
+  # 
+  Rollbar.report_message("Custom message")
+  #
+  Rollbar.report_exception(env['sinatra.error'])
+  #
+  "error"
+end
+
+
+
 get '/' do
-  begin
-    foo = bar
-  rescue => e
-    Rollbar.report_exception(e)
-  end
-
-  Rollbar.report_message("test message")
-
+  raise RuntimeError, "custom message"
   "Hello world!"
 end
 


### PR DESCRIPTION
Hi! 

I have a quite large Sinatra application that is compose of multiple Sinatra apps. Moreover, rack is being used to mount each app into a URL endpoint. For example: /admin, /api, /report 

I created this pull request to demostrate how we can catch all the error using the Sinatra error block. Therefore, not mixing error reporting code on our endpoint. I really didn't want to use begin rescue into each action. 

If you feel it is a good idea, I could create another example becuase I subclass Sinatra::Base and did something like: 

``` ruby
class MealsSinatraBase < Sinatra::Base

  configure do
    Rollbar.configure do |config|
      config.access_token = ''
      config.environment = Sinatra::Base.environment
      config.root = Dir.pwd
    end
  end

  error do
    Rollbar.report_exception(env['sinatra.error'])
    "error"
  end
end

class AdminApp < MealsSinatraBase
end

class ReportApp < MealsSinatraBase
end

class API < MealsSinatraBase
end
```

I hope this help other Sinatra heads. 

:thumbsup: 
